### PR TITLE
Initialize Debarulers website

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+concurrency:
+  group: deploy
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - uses: actions/configure-pages@v5
+      - uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.123.7'
+          extended: true
+      - run: hugo --minify
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./public
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
+# Debarulers Hugo Site
 
+Static website for the alternative rock band **Debarulers**.
+
+## Requirements
+- Hugo 0.123+
+
+## Development
+Run the local server:
+
+```bash
+hugo server
+```

--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,0 +1,5 @@
++++
+title = '{{ replace .File.ContentBaseName "-" " " | title }}'
+date = {{ .Date }}
+draft = true
++++

--- a/content/en/_index.md
+++ b/content/en/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Home"
+---
+
+![Debarulers](/img/debarulers.jpg)
+
+Alternative rock from Lyon since 2018. Influences: Foo Fighters, Queens of the Stone Age, Baroness, Mastodon.
+
+[Instagram](https://instagram.com/debarulers_band) | [YouTube](https://youtube.com/@debarulers)

--- a/content/en/concerts/_index.md
+++ b/content/en/concerts/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Gigs"
+---
+
+Upcoming gigs.

--- a/content/en/contact/_index.md
+++ b/content/en/contact/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Contact"
+---
+
+<form action="https://formspree.io/f/moqzjjvv" method="POST">
+  <label>Your email:<br><input type="email" name="email" required></label><br>
+  <label>Message:<br><textarea name="message" required></textarea></label><br>
+  <button type="submit">Send</button>
+</form>
+
+[Instagram](https://instagram.com/debarulers_band) | [Email](mailto:contact@debarulers.com)

--- a/content/en/music/_index.md
+++ b/content/en/music/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Music"
+---
+
+### EP *Drifting Away* (January 2025)
+
+1. **Lullaby to Paradise**
+
+<iframe src="https://open.spotify.com/embed/track/placeholder1" width="100%" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+
+2. **My Fantasy**
+
+<iframe src="https://open.spotify.com/embed/track/placeholder2" width="100%" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+
+3. **Under The Canopy**
+
+<iframe src="https://open.spotify.com/embed/track/placeholder3" width="100%" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+
+[Bandcamp](https://bandcamp.com) | [Deezer](https://www.deezer.com)

--- a/content/en/technical-rider/_index.md
+++ b/content/en/technical-rider/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Technical Rider"
+---
+
+_Coming soon. Full Setup and Small Setup available as PDF._

--- a/content/fr/_index.md
+++ b/content/fr/_index.md
@@ -1,0 +1,9 @@
+---
+title: "Accueil"
+---
+
+![Debarulers](/img/debarulers.jpg)
+
+Rock alternatif lyonnais depuis 2018. Influences : Foo Fighters, Queens of the Stone Age, Baroness, Mastodon.
+
+[Instagram](https://instagram.com/debarulers_band) | [YouTube](https://youtube.com/@debarulers)

--- a/content/fr/concerts/_index.md
+++ b/content/fr/concerts/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Concerts"
+---
+
+Liste des prochains concerts.

--- a/content/fr/contact/_index.md
+++ b/content/fr/contact/_index.md
@@ -1,0 +1,11 @@
+---
+title: "Contact"
+---
+
+<form action="https://formspree.io/f/moqzjjvv" method="POST">
+  <label>Votre email:<br><input type="email" name="email" required></label><br>
+  <label>Message:<br><textarea name="message" required></textarea></label><br>
+  <button type="submit">Envoyer</button>
+</form>
+
+[Instagram](https://instagram.com/debarulers_band) | [Email](mailto:contact@debarulers.com)

--- a/content/fr/musique/_index.md
+++ b/content/fr/musique/_index.md
@@ -1,0 +1,19 @@
+---
+title: "Musique"
+---
+
+### EP *Drifting Away* (janvier 2025)
+
+1. **Lullaby to Paradise**
+
+<iframe src="https://open.spotify.com/embed/track/placeholder1" width="100%" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+
+2. **My Fantasy**
+
+<iframe src="https://open.spotify.com/embed/track/placeholder2" width="100%" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+
+3. **Under The Canopy**
+
+<iframe src="https://open.spotify.com/embed/track/placeholder3" width="100%" height="80" frameborder="0" allowtransparency="true" allow="encrypted-media"></iframe>
+
+[Bandcamp](https://bandcamp.com) | [Deezer](https://www.deezer.com)

--- a/content/fr/technical-rider/_index.md
+++ b/content/fr/technical-rider/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Technical Rider"
+---
+
+_Coming soon. Full Setup and Small Setup available as PDF._

--- a/data/concerts.yaml
+++ b/data/concerts.yaml
@@ -1,0 +1,8 @@
+- date: 2025-03-15
+  venue: "Le Rock Club"
+  city: "Lyon"
+  tickets: "https://example.com/billet1"
+- date: 2025-04-20
+  venue: "Festival Rock"
+  city: "Paris"
+  tickets: "https://example.com/billet2"

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,0 +1,43 @@
+baseURL = 'https://example.com/'
+languageCode = 'fr'
+title = 'Debarulers'
+theme = 'hugo-music'
+defaultContentLanguage = 'fr'
+defaultContentLanguageInSubdir = true
+[markup]
+  [markup.goldmark]
+    [markup.goldmark.renderer]
+      unsafe = true
+[languages]
+  [languages.fr]
+    languageName = 'Français'
+    weight = 1
+  [languages.en]
+    languageName = 'English'
+    weight = 2
+[menu]
+  [[menu.main]]
+    identifier = 'home'
+    name = 'Home'
+    url = '/' 
+    weight = 1
+  [[menu.main]]
+    identifier = 'music'
+    name = 'Music'
+    url = '/music/'
+    weight = 2
+  [[menu.main]]
+    identifier = 'concerts'
+    name = 'Concerts'
+    url = '/concerts/'
+    weight = 3
+  [[menu.main]]
+    identifier = 'rider'
+    name = 'Technical Rider'
+    url = '/technical-rider/'
+    weight = 4
+  [[menu.main]]
+    identifier = 'contact'
+    name = 'Contact'
+    url = '/contact/'
+    weight = 5

--- a/layouts/concerts/list.html
+++ b/layouts/concerts/list.html
@@ -1,0 +1,14 @@
+{{ define "main" }}
+<h2>{{ .Title }}</h2>
+<table>
+<tr><th>Date</th><th>Lieu</th><th>Ville</th><th>Billetterie</th></tr>
+{{ range site.Data.concerts }}
+<tr>
+  <td>{{ .date }}</td>
+  <td>{{ .venue }}</td>
+  <td>{{ .city }}</td>
+  <td><a href="{{ .tickets }}">Lien</a></td>
+</tr>
+{{ end }}
+</table>
+{{ end }}

--- a/static/img/debarulers.jpg
+++ b/static/img/debarulers.jpg
@@ -1,0 +1,1 @@
+placeholder

--- a/themes/hugo-music/layouts/_default/baseof.html
+++ b/themes/hugo-music/layouts/_default/baseof.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="{{ .Site.Language.Lang }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ block "title" . }}{{ .Site.Title }}{{ end }}</title>
+    <link rel="stylesheet" href="/css/style.css">
+</head>
+<body>
+<header>
+  <h1><a href="{{ "/" | relLangURL }}">{{ .Site.Title }}</a></h1>
+  <nav>
+    <a href="{{ relLangURL "/" }}">Home</a>
+    <a href="{{ relLangURL "/musique/" }}">Musique</a>
+    <a href="{{ relLangURL "/concerts/" }}">Concerts</a>
+    <a href="{{ relLangURL "/technical-rider/" }}">Technical Rider</a>
+    <a href="{{ relLangURL "/contact/" }}">Contact</a>
+  </nav>
+</header>
+<main>
+  {{ block "main" . }}{{ end }}
+</main>
+<footer>
+  <p>&copy; {{ now.Format "2006" }} Debarulers</p>
+</footer>
+</body>
+</html>

--- a/themes/hugo-music/layouts/_default/list.html
+++ b/themes/hugo-music/layouts/_default/list.html
@@ -1,0 +1,8 @@
+{{ define "main" }}
+  <h2>{{ .Title }}</h2>
+  <ul>
+  {{ range .Pages }}
+    <li><a href="{{ .RelPermalink }}">{{ .Title }}</a></li>
+  {{ end }}
+  </ul>
+{{ end }}

--- a/themes/hugo-music/layouts/_default/single.html
+++ b/themes/hugo-music/layouts/_default/single.html
@@ -1,0 +1,4 @@
+{{ define "main" }}
+  <h2>{{ .Title }}</h2>
+  {{ .Content }}
+{{ end }}

--- a/themes/hugo-music/static/css/style.css
+++ b/themes/hugo-music/static/css/style.css
@@ -1,0 +1,6 @@
+body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+header { background: #222; color: #fff; padding: 1rem; }
+header nav a { color: #fff; margin-right: 1rem; text-decoration: none; }
+main { padding: 1rem; }
+footer { background: #eee; padding: 1rem; text-align: center; }
+img { max-width: 100%; height: auto; }


### PR DESCRIPTION
## Summary
- initialize Hugo site with a custom `hugo-music` theme clone
- add French and English pages (Home, Music, Concerts, Technical Rider, Contact)
- store upcoming shows in YAML data
- add basic styling and layout
- configure GitHub Pages deployment
- update workflow to latest artifact actions

## Testing
- `hugo`


------
https://chatgpt.com/codex/tasks/task_e_6885d4becdcc832a8cd79e304b7a13b9