### PR TITLE
Fix header and menu links

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -17,27 +17,27 @@ defaultContentLanguageInSubdir = true
       [[languages.fr.menu.main]]
         identifier = 'home'
         name = 'Accueil'
-        url = '/'
+        url = ''
         weight = 1
       [[languages.fr.menu.main]]
         identifier = 'music'
         name = 'Musique'
-        url = '/musique/'
+        url = 'musique/'
         weight = 2
       [[languages.fr.menu.main]]
         identifier = 'concerts'
         name = 'Concerts'
-        url = '/concerts/'
+        url = 'concerts/'
         weight = 3
       [[languages.fr.menu.main]]
         identifier = 'rider'
         name = 'Technical Rider'
-        url = '/technical-rider/'
+        url = 'technical-rider/'
         weight = 4
       [[languages.fr.menu.main]]
         identifier = 'contact'
         name = 'Contact'
-        url = '/contact/'
+        url = 'contact/'
         weight = 5
   [languages.en]
     languageName = 'English'
@@ -46,25 +46,25 @@ defaultContentLanguageInSubdir = true
       [[languages.en.menu.main]]
         identifier = 'home'
         name = 'Home'
-        url = '/'
+        url = ''
         weight = 1
       [[languages.en.menu.main]]
         identifier = 'music'
         name = 'Music'
-        url = '/music/'
+        url = 'music/'
         weight = 2
       [[languages.en.menu.main]]
         identifier = 'concerts'
         name = 'Concerts'
-        url = '/concerts/'
+        url = 'concerts/'
         weight = 3
       [[languages.en.menu.main]]
         identifier = 'rider'
         name = 'Technical Rider'
-        url = '/technical-rider/'
+        url = 'technical-rider/'
         weight = 4
       [[languages.en.menu.main]]
         identifier = 'contact'
         name = 'Contact'
-        url = '/contact/'
+        url = 'contact/'
         weight = 5

--- a/themes/hugo-music/layouts/_default/baseof.html
+++ b/themes/hugo-music/layouts/_default/baseof.html
@@ -8,7 +8,7 @@
 </head>
 <body>
 <header>
-  <h1><a href="{{ "/" | relLangURL }}">{{ .Site.Title }}</a></h1>
+  <h1><a href="{{ "" | relLangURL }}">{{ .Site.Title }}</a></h1>
   <nav>
     {{ range .Site.Menus.main }}
       <a href="{{ .URL | relLangURL }}">{{ .Name }}</a>


### PR DESCRIPTION
## Summary
- fix header logo link so it respects language subfolders
- adjust menu configuration to avoid double `debarulers` in URLs

## Testing
- `hugo --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6885e0c37d5c832aaace0559869ec656